### PR TITLE
Target .net 3.5 rather than .net 4.0

### DIFF
--- a/AnotherJiraRestClient.csproj
+++ b/AnotherJiraRestClient.csproj
@@ -10,8 +10,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AnotherJiraRestClient</RootNamespace>
     <AssemblyName>AnotherJiraRestClient</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,15 +31,18 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RestSharp">
-      <HintPath>packages\RestSharp.104.1\lib\net4\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp, Version=105.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>packages\RestSharp.105.0.1\lib\net35\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -61,7 +65,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/JiraClient.cs
+++ b/JiraClient.cs
@@ -1,6 +1,7 @@
 ﻿using AnotherJiraRestClient.JiraModel;
 using RestSharp;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 
 namespace AnotherJiraRestClient
@@ -66,7 +67,7 @@ namespace AnotherJiraRestClient
         private static string ToCommaSeparatedString(IEnumerable<string> strings)
         {
             if (strings != null)
-                return string.Join(",", strings);
+                return string.Join(",", strings.ToArray());
             else
                 return string.Empty;
         }
@@ -286,8 +287,8 @@ namespace AnotherJiraRestClient
             var response = client.Execute(request);
             if (response.ResponseStatus != ResponseStatus.Completed || response.StatusCode != HttpStatusCode.NoContent)
                 throw new JiraApiException("Failed to delete attachment with id=" + attachmentId);
-        }        
-        
+        }
+
         /// <summary>
         /// Update time tracking estimates
         /// </summary>

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RestSharp" version="103.1" />
-  <package id="RestSharp" version="103.4" />
-  <package id="RestSharp" version="104.1" targetFramework="net40" />
+  <package id="RestSharp" version="103.1" requireReinstallation="True" />
+  <package id="RestSharp" version="103.4" requireReinstallation="True" />
+  <package id="RestSharp" version="105.0.1" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
There's no real reason to target .net 4.0. With one small change it is able to target .net 3.5 which will make it usable by many more people.
